### PR TITLE
Update default server image to debian-13 and remove Trixie upgrade

### DIFF
--- a/create_hetzner.yaml
+++ b/create_hetzner.yaml
@@ -18,7 +18,7 @@
 
     - name: server_image
       prompt: Server Image des zu erstellenden Servers eingeben
-      default: debian-12
+      default: debian-13
       private: false
 
     - name: server_location

--- a/roles/server-setup/tasks/main.yml
+++ b/roles/server-setup/tasks/main.yml
@@ -35,67 +35,21 @@
     autoremove: yes
   ignore_errors: true
 
-# Start Workaround Trixie Update >>>
-
-- name: Hauptquellen-Datei auf trixie anpassen
-  ansible.builtin.replace:
-    path: /etc/apt/sources.list
-    regexp: 'bookworm'
-    replace: 'trixie'
-
-- name: Prüfen, ob /etc/apt/sources.list.d existiert
-  ansible.builtin.stat:
-    path: /etc/apt/sources.list.d
-  register: sources_d
-
-- name: Alle .list-Dateien in sources.list.d sammeln (nur wenn vorhanden)
-  ansible.builtin.find:
-    paths: /etc/apt/sources.list.d
-    patterns: "*.list"
-    file_type: file
-  when: sources_d.stat.exists
-  register: list_files
-  become: true
-
-- name: Zusätzliche Quellen (sources.list.d) anpassen
-  ansible.builtin.replace:
-    path: "{{ item.path }}"
-    regexp: 'bookworm'
-    replace: 'trixie'
-  loop: "{{ list_files.files | default([]) }}"
-  when: sources_d.stat.exists
-  become: true
-
-- name: Paketlisten aktualisieren
-  ansible.builtin.apt:
-    update_cache: yes
-
-- name: Distribution Upgrade durchführen
-  ansible.builtin.apt:
-    upgrade: dist
-    autoremove: no
-
-- name: Unbenutzte Pakete entfernen (I)
-  ansible.builtin.apt:
-    autoremove: yes
-    autoclean: yes
-
-- name: Unbenutzte Pakete entfernen (II)
-  ansible.builtin.apt:
-    autoremove: yes
-    purge: yes
-
-# End Workaround Trixie Update <<<
-
 - name: SSH Hardening
   lineinfile:
     path: /etc/ssh/sshd_config
     regexp: "{{ item.regexp }}"
     line: "{{ item.line }}"
   loop:
-    - { regexp: "^#?PermitRootLogin.*", line: "PermitRootLogin prohibit-password" }
+    - {
+        regexp: "^#?PermitRootLogin.*",
+        line: "PermitRootLogin prohibit-password",
+      }
     - { regexp: "^#AddressFamily any", line: "AddressFamily inet" }
-    - { regexp: "^#PasswordAuthentication yes", line: "PasswordAuthentication no" }
+    - {
+        regexp: "^#PasswordAuthentication yes",
+        line: "PasswordAuthentication no",
+      }
 
 - name: SSH neu starten
   systemd:


### PR DESCRIPTION
workaround

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Default server image updated to Debian 13 for new deployments.
- Bug Fixes
  - Improved SSH hardening application by reliably disabling password authentication, reducing misconfigurations across fresh installs.
- Refactor
  - Removed legacy Debian upgrade workaround to streamline provisioning and reduce potential errors during setup.
- Chores
  - General cleanup of task definitions to align with current provisioning flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->