### PR TITLE
Add ctop installation to container-tools role

### DIFF
--- a/roles/container-tools/README.md
+++ b/roles/container-tools/README.md
@@ -5,12 +5,13 @@ This role installs and configures container tools on a Debian-based server.
 ## Features
 
 - Installation of Docker via the official install script
+- Installation of [ctop](https://github.com/bcicen/ctop) (top-like interface for container metrics)
 
 ## Variables
 
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
-| install_docker | False | Enables the installation of Docker |
+| install_docker | False | Enables the installation of Docker and ctop |
 
 ## Example
 
@@ -29,4 +30,5 @@ This role has no external dependencies but requires internet access to download 
 
 - Docker is only installed when the `install_docker` variable is set to `True`.
 - Installation is done via the official Docker install script.
-- After installation, Docker containers can be used without additional configuration.
+- ctop is automatically installed alongside Docker and placed in `/usr/local/bin/ctop`.
+- The latest ctop release is fetched dynamically from the GitHub API during installation.

--- a/roles/container-tools/tasks/main.yml
+++ b/roles/container-tools/tasks/main.yml
@@ -9,3 +9,17 @@
   args:
     creates: /usr/bin/docker
   when: install_docker | default(False)
+
+- name: Aktuelle ctop-Version ermitteln
+  uri:
+    url: https://api.github.com/repos/bcicen/ctop/releases/latest
+    return_content: true
+  register: ctop_release
+  when: install_docker | default(False)
+
+- name: ctop installieren
+  get_url:
+    url: "https://github.com/bcicen/ctop/releases/download/{{ ctop_release.json.tag_name }}/ctop-{{ ctop_release.json.tag_name | regex_replace('^v', '') }}-linux-amd64"
+    dest: /usr/local/bin/ctop
+    mode: "0755"
+  when: install_docker | default(False)


### PR DESCRIPTION
Installs ctop alongside Docker by fetching the latest release from the GitHub API and placing the binary in /usr/local/bin/ctop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic installation of ctop alongside Docker.
  * ctop binary is installed to /usr/local/bin/ctop with the latest version dynamically fetched from GitHub API during setup.

* **Documentation**
  * Updated documentation to reflect ctop as a new included component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->