### PR TITLE
Enable Tailscale DNS acceptance for new servers

### DIFF
--- a/playbooks/infrastructure/create-debian-lxc-pve.yaml
+++ b/playbooks/infrastructure/create-debian-lxc-pve.yaml
@@ -195,7 +195,7 @@
             name: artis3n.tailscale.machine
           vars:
             tailscale_authkey: "{{ lookup('community.general.onepassword', 'Tailscale Token' , field='Anmeldedaten', vault='CI') }}"
-            tailscale_args: "--ssh --accept-dns=false --accept-routes=false --advertise-exit-node"
+            tailscale_args: "--ssh --accept-dns=true --accept-routes=false --advertise-exit-node"
           when: tailscale_running.rc != 0
       when: tailscale|bool
 

--- a/playbooks/infrastructure/create-hetzner.yaml
+++ b/playbooks/infrastructure/create-hetzner.yaml
@@ -116,7 +116,7 @@
             name: artis3n.tailscale.machine
           vars:
             tailscale_authkey: "{{ tailscale_token }}"
-            tailscale_args: "--ssh --accept-dns=false --accept-routes=false --advertise-exit-node"
+            tailscale_args: "--ssh --accept-dns=true --accept-routes=false --advertise-exit-node"
           when: tailscale_running.rc != 0
       when: tailscale | bool
 

--- a/playbooks/system/setup-generic-debian-by-ip.yaml
+++ b/playbooks/system/setup-generic-debian-by-ip.yaml
@@ -92,7 +92,7 @@
             name: artis3n.tailscale.machine
           vars:
             tailscale_authkey: "{{ lookup('community.general.onepassword', 'Tailscale Token - Remote Server' , field='Anmeldedaten', vault='CI') }}"
-            tailscale_args: "--ssh --accept-dns=false --accept-routes=false --advertise-exit-node"
+            tailscale_args: "--ssh --accept-dns=true --accept-routes=false --advertise-exit-node"
           when: tailscale_running.rc != 0
       when: tailscale|bool
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Tailscale DNS configuration across multiple infrastructure deployment types to enable DNS acceptance by default. This change applies to Debian LXC container deployments, Hetzner cloud server setups, and generic Debian system initialization procedures. DNS queries will now be routed through Tailscale in these environments automatically during infrastructure deployment and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->