### PR TITLE
Add Proxmox resource pool to LXC container creation

### DIFF
--- a/playbooks/infrastructure/create-debian-lxc-pve.yaml
+++ b/playbooks/infrastructure/create-debian-lxc-pve.yaml
@@ -11,6 +11,7 @@
     proxmox_token_secret: "{{ lookup('community.general.onepassword', 'Proxmox API' , field='Anmeldedaten', vault='CI') }}"
     mba_pubkey: "{{ lookup('community.general.onepassword', 'MBA SSH - Public Key' , field='Benutzername', vault='CI') }}"
     tailscale_token: "{{ lookup('community.general.onepassword', 'Tailscale Token' , field='Anmeldedaten', vault='CI') }}"
+    proxmox_pool: "{{ lookup('community.general.onepassword', 'Proxmox API' , field='Pool', vault='CI') }}"
 
   vars_prompt:
     - name: server_name
@@ -97,6 +98,7 @@
             ostemplate: "local:vztmpl/debian-13-standard_13.1-2_amd64.tar.zst"
             timezone: host
             unprivileged: true
+            pool: "{{ proxmox_pool }}"
             features:
               - nesting=1
           register: lxc_info


### PR DESCRIPTION
Fetch pool name from 1Password and pass it to the Proxmox API when creating new LXC containers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LXC containers on Proxmox can now be assigned to specific resource pools during provisioning.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elcajon/ansible/pull/56)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->