### PR TITLE
Add security updates and measurements

### DIFF
--- a/inventories/host_vars/proxmox.yml
+++ b/inventories/host_vars/proxmox.yml
@@ -1,0 +1,8 @@
+---
+# Host-spezifische Variablen für den Proxmox-Hypervisor.
+
+# Kein unkontrollierter automatischer Reboot durch unattended-upgrades:
+# Auf dem Hypervisor würde ein automatischer Reboot alle laufenden VMs/LXCs
+# mitnehmen. Sicherheitsupdates werden weiterhin installiert, der Reboot muss
+# hier aber bewusst manuell (oder in einem Wartungsfenster) erfolgen.
+unattended_automatic_reboot: false

--- a/roles/base-system/tasks/macos.yml
+++ b/roles/base-system/tasks/macos.yml
@@ -56,5 +56,5 @@
 - name: Run macOS software update (install all updates)
   shell: softwareupdate -i -a
   register: softwareupdate_result
-  changed_when: "'No updates are available.' not in softwareupdate_result.stdout"
+  changed_when: "'No updates are available.' not in (softwareupdate_result.stdout + softwareupdate_result.stderr)"
   failed_when: softwareupdate_result.rc != 0 and softwareupdate_result.rc != 2

--- a/roles/security/README.md
+++ b/roles/security/README.md
@@ -4,16 +4,25 @@ This role implements basic security measures on a Debian-based server.
 
 ## Features
 
-- SSH hardening and security
+- SSH hardening via a drop-in file (`/etc/ssh/sshd_config.d/99-hardening.conf`)
+  so it cannot be overridden by cloud-init or distribution drop-ins. The
+  effective configuration is validated with `sshd -t` before SSH is restarted,
+  and SSH is only restarted when the configuration actually changed.
 - Optional: Disable SSH service (for systems that should only be accessible via Tailscale)
 - Enable IPv4 & IPv6 forwarding
-- Configuration of unattended-upgrades for automatic security updates
+- Configuration of unattended-upgrades for automatic security updates,
+  including automatic reboots when an update requires one
+- Maintenance checks: ensures time synchronization (systemd-timesyncd) is
+  active and reports a pending reboot in the play output
 
 ## Variables
 
 | Variable | Default Value | Description |
 |----------|---------------|-------------|
-| disable_ssh_for_tailscale | False | If True, the SSH service will be disabled (for systems that should only be accessible via Tailscale) |
+| disable_ssh_for_tailscale | `False` | If `True`, the SSH service is disabled (for hosts that should only be reachable via Tailscale). |
+| ssh_hardening_options | see [defaults/main.yml](defaults/main.yml) | List of directives written to the SSH hardening drop-in. `PermitRootLogin prohibit-password` is kept because Ansible connects as root via SSH key. |
+| unattended_automatic_reboot | `True` | Automatically reboot when `/var/run/reboot-required` exists after an unattended upgrade (e.g. kernel/glibc updates). Set to `False` per host (e.g. Proxmox hypervisors) to avoid uncontrolled reboots. |
+| unattended_automatic_reboot_time | `"02:00"` | Time of day for the automatic reboot. |
 
 ## Example
 
@@ -24,10 +33,24 @@ This role implements basic security measures on a Debian-based server.
       disable_ssh_for_tailscale: True
 ```
 
+Disable the automatic reboot on a specific host (e.g. a Proxmox hypervisor) via
+`host_vars`:
+
+```yaml
+# host_vars/proxmox.yml
+unattended_automatic_reboot: false
+```
+
 ## Dependencies
 
-This role has no external dependencies but assumes that the corresponding SSH services are installed on the system.
+This role has no external dependencies but assumes that the corresponding SSH
+services are installed on the system.
 
 ## Notes
 
-IPv4 & IPv6 forwarding is included in this role because it affects security-related network configurations and is often used in conjunction with firewalls and VPN solutions.
+- IPv4 & IPv6 forwarding is included in this role because it affects
+  security-related network configurations and is often used in conjunction with
+  firewalls and VPN solutions.
+- This role does **not** manage a host firewall. Firewalling is handled outside
+  Ansible: a Hetzner Cloud Firewall for the public host, and the Proxmox VE
+  firewall for the local hosts.

--- a/roles/security/defaults/main.yml
+++ b/roles/security/defaults/main.yml
@@ -1,4 +1,27 @@
 #SPDX-License-Identifier: MIT-0
 ---
 # defaults file for security
+
+# SSH-Dienst deaktivieren, wenn der Host nur über Tailscale erreichbar sein soll
 disable_ssh_for_tailscale: False
+
+# --- SSH-Hardening ---
+# Wird als Drop-in nach /etc/ssh/sshd_config.d/99-hardening.conf geschrieben,
+# damit es nicht von Cloud-Init- oder Distributions-Drop-ins überschrieben wird.
+# PermitRootLogin bleibt "prohibit-password", da sich Ansible als root per
+# SSH-Key verbindet – nur Passwort-Login für root wird unterbunden.
+ssh_hardening_options:
+  - PermitRootLogin prohibit-password
+  - PasswordAuthentication no
+  - KbdInteractiveAuthentication no
+  - PermitEmptyPasswords no
+  - X11Forwarding no
+  - MaxAuthTries 3
+  - AddressFamily inet
+
+# --- Unattended-Upgrades ---
+# Automatischer Reboot, wenn nach einem Update /var/run/reboot-required existiert
+# (z. B. nach Kernel- oder glibc-Updates). Pro Host abschaltbar, z. B. auf
+# Proxmox-Hypervisoren via host_vars: unattended_automatic_reboot: false
+unattended_automatic_reboot: true
+unattended_automatic_reboot_time: "02:00"

--- a/roles/security/tasks/main.yml
+++ b/roles/security/tasks/main.yml
@@ -6,30 +6,67 @@
   ansible.builtin.package_facts:
     manager: auto
 
-- name: SSH Hardening
-  # Konfiguriert die SSH-Einstellungen für erhöhte Sicherheit
+- name: Sicherstellen, dass sshd_config Drop-ins zuerst lädt
+  # OpenSSH wertet bei den meisten Optionen den ersten Treffer aus. Das Drop-in
+  # greift daher nur, wenn die Include-Zeile am Dateianfang steht.
   lineinfile:
     path: /etc/ssh/sshd_config
-    regexp: "{{ item.regexp }}"
-    line: "{{ item.line }}"
-  loop:
-    - {
-        regexp: "^#?PermitRootLogin.*",
-        line: "PermitRootLogin prohibit-password", # Nur SSH-Key-Authentifizierung für Root erlauben
-      }
-    - { regexp: "^#AddressFamily any", line: "AddressFamily inet" } # Nur IPv4 für SSH verwenden
-    - {
-        regexp: "^#PasswordAuthentication yes",
-        line: "PasswordAuthentication no", # Passwort-Authentifizierung deaktivieren
-      }
+    line: "Include /etc/ssh/sshd_config.d/*.conf"
+    regexp: '^\s*Include\s+/etc/ssh/sshd_config\.d/\*\.conf'
+    insertbefore: BOF
+    firstmatch: true
+  register: ssh_include
+  when: "'openssh-server' in ansible_facts.packages"
+
+- name: SSH Hardening (Drop-in-Konfiguration)
+  # Schreibt die Hardening-Einstellungen als Drop-in. Dieses wird nach der
+  # Haupt-sshd_config und nach Cloud-Init-Drop-ins geladen und kann daher
+  # nicht versehentlich überschrieben werden (z. B. PasswordAuthentication).
+  copy:
+    dest: /etc/ssh/sshd_config.d/99-hardening.conf
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      # Managed by Ansible (security role) - nicht manuell bearbeiten
+      {% for option in ssh_hardening_options %}
+      {{ option }}
+      {% endfor %}
+  register: ssh_hardening
+  when: "'openssh-server' in ansible_facts.packages"
+
+- name: Privilege-Separation-Verzeichnis für die sshd-Validierung sicherstellen
+  # sshd -t benötigt /run/sshd. Bei nur über Tailscale erreichbaren Hosts ist
+  # der SSH-Dienst gestoppt, daher fehlt das Verzeichnis (tmpfs). Es wird sonst
+  # vom Dienst beim Start angelegt.
+  file:
+    path: /run/sshd
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when:
+    - "'openssh-server' in ansible_facts.packages"
+    - ssh_hardening is changed or ssh_include is changed
+
+- name: SSH-Konfiguration validieren
+  # Prüft die gesamte effektive Konfiguration inkl. des neuen Drop-ins, bevor
+  # SSH neu gestartet wird – verhindert ein Aussperren durch Syntaxfehler.
+  command: sshd -t
+  changed_when: false
+  when:
+    - "'openssh-server' in ansible_facts.packages"
+    - ssh_hardening is changed or ssh_include is changed
 
 - name: SSH neu starten
-  # SSH-Dienst neu starten, um die Konfigurationsänderungen zu übernehmen
+  # SSH-Dienst nur neu starten, wenn sich die Konfiguration geändert hat
   systemd:
     name: ssh
     state: restarted
   ignore_errors: true # Fehler ignorieren, falls SSH nicht installiert ist
-  when: "'openssh-server' in ansible_facts.packages"
+  when:
+    - "'openssh-server' in ansible_facts.packages"
+    - ssh_hardening is changed or ssh_include is changed
 
 - name: SSH deaktivieren (Login nur über Tailscale)
   # Deaktiviert den SSH-Dienst, wenn der Server nur über Tailscale erreichbar sein soll
@@ -65,6 +102,7 @@
     owner: root
     group: root
     mode: "0755"
+  register: unattended_upgrades_config
 
 - name: Unattended-Upgrades aktivieren
   # Aktiviert automatische Updates über das Debconf-System
@@ -73,7 +111,12 @@
     question: unattended-upgrades/enable_auto_updates
     value: "true"
     vtype: boolean
+  register: unattended_upgrades_debconf
 
 - name: Unattended-Upgrades konfigurieren
-  # Wendet die Konfiguration an ohne interaktive Eingabe
+  # Wendet die Konfiguration nur an, wenn sich Template oder Debconf geändert haben
   command: dpkg-reconfigure -f noninteractive unattended-upgrades
+  when: unattended_upgrades_config is changed or unattended_upgrades_debconf is changed
+
+- name: System-Wartung (Zeitsynchronisation & Reboot-Check)
+  ansible.builtin.import_tasks: maintenance.yml

--- a/roles/security/tasks/maintenance.yml
+++ b/roles/security/tasks/maintenance.yml
@@ -1,0 +1,49 @@
+#SPDX-License-Identifier: MIT-0
+---
+# Regelmäßige Wartungs-Checks: Zeitsynchronisation und Reboot-Bedarf.
+
+- name: Container-Status ermitteln
+  # In Containern (z. B. Proxmox LXC) wird die Uhr vom Host gesteuert; ein
+  # eigener Zeitsync-Dienst kann die Zeit nicht setzen und meldet bei jedem Lauf
+  # fälschlich "changed". Solche Hosts werden bei der Zeitsync übersprungen.
+  ansible.builtin.set_fact:
+    is_container: "{{ ansible_facts['virtualization_role'] == 'guest' and ansible_facts['virtualization_type'] in ['lxc', 'systemd-nspawn', 'docker', 'container', 'openvz', 'podman'] }}"
+
+- name: Vorhandene Dienste ermitteln
+  ansible.builtin.service_facts:
+  when: not (is_container | bool)
+
+- name: systemd-timesyncd installieren, falls keine Zeitsynchronisation vorhanden
+  # Korrekte Uhrzeit ist sicherheitsrelevant (TLS-Validierung, Log-Forensik).
+  apt:
+    name: systemd-timesyncd
+    state: present
+  when:
+    - not (is_container | bool)
+    - "'chrony.service' not in ansible_facts.services"
+    - "'ntp.service' not in ansible_facts.services"
+    - "'systemd-timesyncd.service' not in ansible_facts.services"
+
+- name: Zeitsynchronisation (systemd-timesyncd) aktivieren
+  systemd:
+    name: systemd-timesyncd
+    enabled: true
+    state: started
+  when:
+    - not (is_container | bool)
+    - "'chrony.service' not in ansible_facts.services"
+    - "'ntp.service' not in ansible_facts.services"
+
+- name: Prüfen, ob ein Reboot erforderlich ist
+  stat:
+    path: /var/run/reboot-required
+  register: reboot_required_file
+
+- name: Hinweis ausgeben, wenn ein Reboot aussteht
+  ansible.builtin.debug:
+    msg: >-
+      ACHTUNG: {{ inventory_hostname }} benötigt einen Reboot
+      (/var/run/reboot-required vorhanden). Wird via unattended-upgrades
+      um {{ unattended_automatic_reboot_time }} Uhr automatisch ausgeführt,
+      sofern unattended_automatic_reboot aktiv ist.
+  when: reboot_required_file.stat.exists

--- a/roles/security/templates/50unattended-upgrades.j2
+++ b/roles/security/templates/50unattended-upgrades.j2
@@ -116,16 +116,17 @@ Unattended-Upgrade::Remove-Unused-Dependencies "true";
 
 // Automatically reboot *WITHOUT CONFIRMATION* if
 //  the file /var/run/reboot-required is found after the upgrade
-//Unattended-Upgrade::Automatic-Reboot "false";
+// Managed by Ansible (security role) via unattended_automatic_reboot
+Unattended-Upgrade::Automatic-Reboot "{{ unattended_automatic_reboot | ternary('true', 'false') }}";
 
 // Automatically reboot even if there are users currently logged in
 // when Unattended-Upgrade::Automatic-Reboot is set to true
-//Unattended-Upgrade::Automatic-Reboot-WithUsers "true";
+Unattended-Upgrade::Automatic-Reboot-WithUsers "true";
 
 // If automatic reboot is enabled and needed, reboot at the specific
 // time instead of immediately
 //  Default: "now"
-//Unattended-Upgrade::Automatic-Reboot-Time "02:00";
+Unattended-Upgrade::Automatic-Reboot-Time "{{ unattended_automatic_reboot_time }}";
 
 // Use apt bandwidth limit feature, this example limits the download
 // speed to 70kb/sec


### PR DESCRIPTION
## Was & Warum

Beim regulären Update-Lauf erzeugten mehrere Tasks bei jedem Durchlauf `changed`, obwohl sich nichts geändert hat. Zusätzlich wurden Lücken in der `security`-Rolle geschlossen.

### Idempotenz-Fixes (kein falsches `changed` mehr)
- **SSH neu starten** (`security`): `state: restarted` lief bei jedem Lauf → jetzt nur noch, wenn sich die SSH-Konfiguration tatsächlich geändert hat. Das behebt auch das Folge-`changed` bei „SSH deaktivieren" (der Restart startete den Dienst, den der Disable-Task danach wieder stoppte).
- **Unattended-Upgrades konfigurieren** (`security`): `dpkg-reconfigure` (nacktes `command`) lief immer → jetzt nur bei Änderung von Template oder Debconf.
- **macOS softwareupdate (install)** (`base-system`): „No updates are available." steht auf neueren macOS-Versionen auf `stderr` → `changed_when` prüft jetzt `stdout + stderr`.
- **Zeitsync in Containern** (`security`): `systemd-timesyncd` kann in LXC die Uhr nicht setzen und meldete dauerhaft `changed` → wird in Containern (Proxmox LXC etc.) übersprungen.

### Sicherheits-Härtung
- **SSH-Hardening als Drop-in**: Konfiguration liegt jetzt in `/etc/ssh/sshd_config.d/99-hardening.conf` (statt direkt in `sshd_config`) und kann nicht mehr von Cloud-Init-Drop-ins überschrieben werden. Sicherstellung, dass die `Include`-Zeile am Dateianfang steht, Validierung mit `sshd -t` vor dem Neustart, und neue Direktiven (`MaxAuthTries`, `X11Forwarding no`, `PermitEmptyPasswords no`, `KbdInteractiveAuthentication no`).
- **Auto-Reboot für Sicherheitsupdates**: `unattended-upgrades` rebootet jetzt automatisch (`unattended_automatic_reboot`, default `true`, Zeit `02:00`), wenn `/var/run/reboot-required` existiert — damit Kernel-/glibc-Updates auch wirksam werden.
- **Proxmox-Schutz**: `host_vars/proxmox.yml` setzt `unattended_automatic_reboot: false`, damit der Hypervisor nicht unkontrolliert rebootet.
- **Wartungs-Checks**: Zeitsynchronisation (systemd-timesyncd) sicherstellen + Hinweis auf ausstehenden Reboot im Play-Output.

## Reviewer-Hinweise
- Firewall wurde bewusst **nicht** in die Rolle aufgenommen: Firewalling läuft extern (Hetzner Cloud Firewall für den public Host, PVE-Firewall für die lokalen Hosts) — siehe README.
- `is_container` wird mit `| bool` ausgewertet, da `set_fact` sonst den String `"False"` liefert (`not "False"` wäre in Jinja `False`).
- Fakt-Zugriffe nutzen `ansible_facts[...]` (zukunftssicher ggü. `INJECT_FACTS_AS_VARS`-Deprecation).
- Drop-in behält `PermitRootLogin prohibit-password`, da Ansible sich als root per SSH-Key verbindet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSH hardening improvements with drop-in configuration approach
  * Configurable automatic reboot options for unattended-upgrades with scheduled reboot times
  * Maintenance checks for time synchronization and pending reboot detection on non-container hosts
  * IPv4/IPv6 forwarding configuration options

* **Bug Fixes**
  * Fixed macOS software update detection to properly check both output streams

* **Documentation**
  * Expanded security documentation with detailed features, variables, and configuration examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->