### PR TITLE
Mask SSH on disable and make IP forwarding idempotent

### DIFF
--- a/roles/security/README.md
+++ b/roles/security/README.md
@@ -8,8 +8,14 @@ This role implements basic security measures on a Debian-based server.
   so it cannot be overridden by cloud-init or distribution drop-ins. The
   effective configuration is validated with `sshd -t` before SSH is restarted,
   and SSH is only restarted when the configuration actually changed.
-- Optional: Disable SSH service (for systems that should only be accessible via Tailscale)
-- Enable IPv4 & IPv6 forwarding
+- Optional: Disable (and mask) the SSH service for systems that should only be
+  accessible via Tailscale. Masking ensures the service stays down even after an
+  `openssh-server` package update would otherwise re-enable it. Access is
+  expected via Tailscale SSH.
+- Enable IPv4 & IPv6 forwarding via a persistent sysctl drop-in
+  (`/etc/sysctl.d/99-ip-forward.conf`), e.g. for Tailscale exit nodes. Managed as
+  a file (not set live) so it stays idempotent even in LXC containers, where the
+  live value resets to 0 on reboot.
 - Configuration of unattended-upgrades for automatic security updates,
   including automatic reboots when an update requires one
 - Maintenance checks: ensures time synchronization (systemd-timesyncd) is

--- a/roles/security/tasks/main.yml
+++ b/roles/security/tasks/main.yml
@@ -69,29 +69,43 @@
     - ssh_hardening is changed or ssh_include is changed
 
 - name: SSH deaktivieren (Login nur über Tailscale)
-  # Deaktiviert den SSH-Dienst, wenn der Server nur über Tailscale erreichbar sein soll
-  # Dies erhöht die Sicherheit, da kein SSH-Zugriff vom öffentlichen Internet möglich ist
+  # Deaktiviert den SSH-Dienst, wenn der Server nur über Tailscale erreichbar sein soll.
+  # masked: true verhindert, dass der Dienst von irgendetwas wieder gestartet wird –
+  # insbesondere durch dpkg-postinst bei einem openssh-server-Update. Ohne Maskierung
+  # kommt SSH nach Paketupdate + Reboot wieder hoch (jedes Mal "changed").
+  # Unkritisch, da der Zugang über Tailscale SSH (--ssh) erfolgt.
   systemd:
     name: "{{ item }}"
     state: stopped
     enabled: false
+    masked: true
   loop:
     - ssh.service
     - ssh.socket
   when: disable_ssh_for_tailscale | default(False) or 'tailscale' in ansible_facts.packages
 
-- name: IPv4 & IPv6 Forwarding aktivieren
-  # Aktiviert IP-Forwarding für IPv4 und IPv6
-  # Notwendig für Routing-Funktionen, VPN-Server und Container-Netzwerke
-  sysctl:
-    name: "{{ item }}"
-    value: 1
-    sysctl_set: true
-    state: present
-    reload: true
-  loop:
-    - net.ipv4.ip_forward
-    - net.ipv6.conf.all.forwarding
+- name: IPv4 & IPv6 Forwarding persistent konfigurieren
+  # Notwendig u. a. für Tailscale-Exit-Nodes (auch in LXC-Containern).
+  # Wird als sysctl-Drop-in verwaltet (nicht live gesetzt), damit der Task
+  # idempotent bleibt: In LXC fällt der Live-Wert nach einem Reboot auf 0
+  # zurück, ein live-prüfender sysctl-Task würde dann bei jedem Lauf "changed"
+  # melden. systemd-sysctl wendet das Drop-in bei jedem Boot an.
+  copy:
+    dest: /etc/sysctl.d/99-ip-forward.conf
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      # Managed by Ansible (security role) - nicht manuell bearbeiten
+      net.ipv4.ip_forward = 1
+      net.ipv6.conf.all.forwarding = 1
+  register: ip_forward_config
+
+- name: IP-Forwarding live anwenden
+  # Nur wenn sich die Drop-in-Datei geändert hat -> kein churn im Normalbetrieb.
+  command: sysctl --system
+  changed_when: false
+  when: ip_forward_config is changed
 
 - name: Unattended-Upgrades Konfiguration kopieren
   # Konfiguriert automatische Sicherheitsupdates


### PR DESCRIPTION
## Was & Warum
Mehrere Tasks meldeten bei jedem Lauf `changed`, obwohl sich nichts änderte;
zusätzlich wurden Lücken in der security-Rolle geschlossen.

### Idempotenz
- SSH-Restart nur noch bei tatsächlicher Konfig-Änderung (behebt auch Folge-changed bei SSH-Disable)
- dpkg-reconfigure (unattended-upgrades) nur bei Änderung von Template/Debconf
- macOS softwareupdate: changed_when prüft jetzt stdout + stderr
- Zeitsync (systemd-timesyncd) wird in LXC-Containern übersprungen
- IP-Forwarding als persistentes sysctl-Drop-in statt live-set → kein churn nach Reboot in LXC
- SSH-Disable maskiert den Dienst, damit ihn ein openssh-Update nicht reaktiviert

### Härtung
- SSH-Hardening als Drop-in (99-hardening.conf), sshd -t-Validierung, zusätzliche Direktiven
- Auto-Reboot für Sicherheitsupdates (unattended_automatic_reboot), proxmox via host_vars ausgenommen
- Wartungs-Checks: Zeitsync sicherstellen + Reboot-Hinweis

## Reviewer-Hinweise
- Firewall bewusst nicht Teil der Rolle (Hetzner Cloud FW + PVE-Firewall extern)
- SSH-Maskierung ist nur sicher, weil Zugang über Tailscale SSH (--ssh) läuft
- is_container nutzt | bool; Fakt-Zugriffe via ansible_facts[...] (INJECT_FACTS_AS_VARS-Deprecation)