### PR TITLE
Komodo Periphery als systemd-Dienst + sysctl-Forwarding-Fix

### DIFF
--- a/playbooks/includes/apply-server-roles.yaml
+++ b/playbooks/includes/apply-server-roles.yaml
@@ -30,6 +30,15 @@
     install_docker: "{{ docker | bool }}"
   when: docker | bool
 
+- name: Set up Komodo Periphery (on Docker hosts)
+  include_role:
+    name: komodo-periphery
+  vars:
+    install_periphery: "{{ docker | bool }}"
+    komodo_api_key: "{{ lookup('community.general.onepassword', 'Komodo', field='Key', vault='CI') }}"
+    komodo_api_secret: "{{ lookup('community.general.onepassword', 'Komodo', field='Secret', vault='CI') }}"
+  when: docker | bool
+
 - name: Set up Newt with Pangolin API integration
   include_role:
     name: pangolin-newt

--- a/playbooks/system/update-inventory.yaml
+++ b/playbooks/system/update-inventory.yaml
@@ -39,3 +39,11 @@
     - name: Update Newt
       ansible.builtin.include_tasks:
         file: ../../roles/pangolin-newt/tasks/update.yml
+
+    - name: Update/Install Komodo Periphery (Docker-Hosts)
+      ansible.builtin.include_role:
+        name: komodo-periphery
+        tasks_from: update.yml
+      vars:
+        komodo_api_key: "{{ lookup('community.general.onepassword', 'Komodo', field='Key', vault='CI') }}"
+        komodo_api_secret: "{{ lookup('community.general.onepassword', 'Komodo', field='Secret', vault='CI') }}"

--- a/roles/komodo-periphery/README.md
+++ b/roles/komodo-periphery/README.md
@@ -1,0 +1,52 @@
+# Komodo Periphery Role
+
+Installs and configures the [Komodo](https://komo.do) Periphery agent **directly
+as a systemd service** (instead of in a container), analogous to the
+`pangolin-newt` role. Targets Komodo v2 (PKI onboarding).
+
+## How it works
+
+- On **first install** (`tasks/komodo_api.yml`), an onboarding key is requested
+  from Komodo Core via the admin API (`POST /write/CreateOnboardingKey`) and
+  written into `periphery.config.toml`. On first connect Periphery generates its
+  own Ed25519 keypair (`{{ periphery_root_directory }}/keys/periphery.key`) and
+  sends only its public key to Core. The onboarding key is then removed from the
+  config (no long-lived secret is stored).
+- The binary is kept current by a daily updater (`/etc/cron.daily/periphery_update`)
+  tracking the latest `moghtech/komodo` release (asset `periphery-{x86_64,aarch64}`).
+  No version pinning.
+- Periphery runs in **outbound mode**: it dials `core_address`; Core does not need
+  to reach the agent's inbound port.
+
+## Setup vs. update
+
+- **Setup** (`apply-server-roles.yaml`): installed on every host where Docker is
+  installed (`install_periphery: "{{ docker | bool }}"`).
+- **Update** (`update-inventory.yaml` → `tasks/update.yml`): if Docker is present,
+  Periphery is updated to the latest version — or installed, for hosts that have
+  Docker but not yet Periphery (transition cases).
+
+## Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `install_periphery` | `false` | Install/configure Periphery on this host. |
+| `komodo_core_address` | `http://100.90.80.191:8080` | Address Periphery dials (outbound mode). Core's **Tailscale IP** — DNS-independent and avoids the `/etc/hosts` short-name trap on the Core host itself (where `pangolin` resolves to `127.0.1.1`). Fallback on IP change: the FQDN `http://pangolin.stern-chimera.ts.net:8080` (never the short name). |
+| `komodo_api_url` | `{{ komodo_core_address }}` | Komodo Core API endpoint for `CreateOnboardingKey`. Must be the **internal** Core address — the public UI URL (`op://CI/Komodo/URL`, `https://komodo.max-venz.io`) sits behind the Pangolin auth proxy and rejects API calls with HTTP 302. |
+| `komodo_api_key` / `komodo_api_secret` | `""` | Admin API credentials. Inject from `op://CI/Komodo/{Key,Secret}`. |
+| `periphery_connect_as` | `{{ server_name \| default(inventory_hostname) }}` | Server name registered in Komodo. |
+| `periphery_root_directory` | `/srv/komodo-periphery` | Root dir (mirrors compose `PERIPHERY_ROOT_DIRECTORY`). |
+| `periphery_stack_dir` | `/srv` | Stack dir (mirrors compose `PERIPHERY_STACK_DIR`). |
+| `periphery_include_disk_mounts` | `[/etc/hostname]` | Disk-report whitelist (mirrors compose). |
+| `periphery_disable_terminals` | `false` | Disable remote shell access. |
+
+## Notes
+
+- Both `komodo_core_address` (agent connection) and `komodo_api_url` (admin API
+  call) use the **internal** Core address (Core's Tailscale IP `100.90.80.191:8080`).
+  The public UI URL `https://komodo.max-venz.io` is behind the Pangolin auth proxy
+  and cannot be used for API calls (returns HTTP 302 to a login page).
+- `connect_as` must match the server name registered in Komodo. When migrating a
+  host from a container-based Periphery, the existing server (and its registered
+  public key) keep their name — either rename the Komodo server to the host's
+  name, or override `periphery_connect_as` for that host.

--- a/roles/komodo-periphery/defaults/main.yml
+++ b/roles/komodo-periphery/defaults/main.yml
@@ -1,0 +1,38 @@
+#SPDX-License-Identifier: MIT-0
+---
+# defaults file for komodo-periphery
+
+# Periphery installieren (wird beim Setup an docker gekoppelt)
+install_periphery: false
+
+# --- Komodo Core Anbindung ---
+# Adresse, zu der Periphery sich verbindet (Outbound-Mode). Bewusst die
+# Tailscale-IP von Core statt eines Hostnamens: komplett unabhängig von DNS/
+# MagicDNS und vermeidet den /etc/hosts-Kurznamen-Fallstrick auf dem Core-Host
+# selbst (dort löst "pangolin" auf 127.0.1.1 -> Connection refused). Die
+# Tailscale-IP ist pro Node stabil.
+# Fallback bei IP-Wechsel: "http://pangolin.stern-chimera.ts.net:8080" (FQDN
+# via MagicDNS) – NICHT der Kurzname "pangolin".
+komodo_core_address: "http://100.90.80.191:8080"
+
+# Komodo-Core-API-Endpoint für Admin-Calls (CreateOnboardingKey).
+# Achtung: NICHT die öffentliche UI-URL (op://CI/Komodo/URL) verwenden – die
+# liegt hinter dem Pangolin-Auth-Proxy und lehnt API-Calls mit 302 ab. Die API
+# wird intern direkt von Core bedient, daher dieselbe Adresse wie core_address.
+komodo_api_url: "{{ komodo_core_address }}"
+komodo_api_key: ""
+komodo_api_secret: ""
+
+# Servername, unter dem sich der Agent bei Komodo meldet (= Hostname).
+periphery_connect_as: "{{ server_name | default(inventory_hostname) }}"
+
+# --- Pfade (gespiegelt aus der docker-compose) ---
+periphery_bin: "/usr/local/bin/periphery"
+periphery_config_path: "/etc/komodo/periphery.config.toml"
+periphery_root_directory: "/srv/komodo-periphery"
+periphery_stack_dir: "/srv"
+
+# --- Verhalten (gespiegelt aus der docker-compose) ---
+periphery_disable_terminals: false
+periphery_include_disk_mounts:
+  - /etc/hostname

--- a/roles/komodo-periphery/handlers/main.yml
+++ b/roles/komodo-periphery/handlers/main.yml
@@ -1,0 +1,12 @@
+#SPDX-License-Identifier: MIT-0
+---
+# handlers file for komodo-periphery
+- name: Reload systemd
+  ansible.builtin.systemd:
+    daemon_reload: true
+
+- name: Enable and start periphery
+  ansible.builtin.systemd:
+    name: periphery
+    state: restarted
+    enabled: true

--- a/roles/komodo-periphery/tasks/komodo_api.yml
+++ b/roles/komodo-periphery/tasks/komodo_api.yml
@@ -1,0 +1,37 @@
+#SPDX-License-Identifier: MIT-0
+---
+# Holt einmalig – nur beim Erstinstall – einen Onboarding-Key von Komodo Core.
+# Sobald Periphery seinen eigenen Key (periphery.key) erzeugt hat, ist der
+# Onboarding-Key überflüssig und wird nicht erneut angefordert.
+
+- name: Prüfen ob Periphery bereits onboarded ist (eigener Key vorhanden)
+  ansible.builtin.stat:
+    path: "{{ periphery_root_directory }}/keys/periphery.key"
+  register: periphery_keyfile
+
+- name: Onboarding-Key von Komodo Core anfordern
+  # Admin-only API. Läuft vom Control-Node aus, damit die API-Credentials nicht
+  # auf die Zielhosts gelangen.
+  ansible.builtin.uri:
+    url: "{{ komodo_api_url }}/write/CreateOnboardingKey"
+    method: POST
+    headers:
+      X-Api-Key: "{{ komodo_api_key }}"
+      X-Api-Secret: "{{ komodo_api_secret }}"
+    body_format: json
+    body:
+      name: "ansible-{{ periphery_connect_as }}"
+    status_code: 200
+  delegate_to: localhost
+  become: false
+  no_log: true
+  register: komodo_onboarding
+  when: not periphery_keyfile.stat.exists
+
+- name: Onboarding-Key übernehmen
+  ansible.builtin.set_fact:
+    periphery_onboarding_key: "{{ komodo_onboarding.json.private_key }}"
+  no_log: true
+  when:
+    - not periphery_keyfile.stat.exists
+    - komodo_onboarding is not skipped

--- a/roles/komodo-periphery/tasks/main.yml
+++ b/roles/komodo-periphery/tasks/main.yml
@@ -1,0 +1,60 @@
+#SPDX-License-Identifier: MIT-0
+---
+# tasks file for komodo-periphery
+# Installiert und konfiguriert den Komodo Periphery Agent als systemd-Dienst
+# (statt im Container) – analog zur pangolin-newt-Rolle.
+
+- name: Onboarding via Komodo API (nur Erstinstall)
+  ansible.builtin.import_tasks: komodo_api.yml
+  when: install_periphery | default(false)
+
+- name: Komodo-Verzeichnisse anlegen
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  loop:
+    - /etc/komodo
+    - "{{ periphery_root_directory }}"
+    - "{{ periphery_root_directory }}/keys"
+  when: install_periphery | default(false)
+
+- name: Update-/Installations-Skript für Periphery kopieren
+  ansible.builtin.template:
+    src: periphery_update.j2
+    dest: /etc/cron.daily/periphery_update
+    owner: root
+    group: root
+    mode: "0755"
+  when: install_periphery | default(false)
+
+- name: Initialer Download der Periphery-Binary
+  ansible.builtin.command: /etc/cron.daily/periphery_update
+  args:
+    creates: "{{ periphery_bin }}"
+  when: install_periphery | default(false)
+
+- name: Periphery-Konfiguration erzeugen
+  ansible.builtin.template:
+    src: periphery.config.toml.j2
+    dest: "{{ periphery_config_path }}"
+    owner: root
+    group: root
+    mode: "0600"
+  notify:
+    - Enable and start periphery
+  when: install_periphery | default(false)
+
+- name: Periphery Systemd Service erzeugen
+  ansible.builtin.template:
+    src: periphery.service.j2
+    dest: /etc/systemd/system/periphery.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Reload systemd
+    - Enable and start periphery
+  when: install_periphery | default(false)

--- a/roles/komodo-periphery/tasks/update.yml
+++ b/roles/komodo-periphery/tasks/update.yml
@@ -1,0 +1,56 @@
+#SPDX-License-Identifier: MIT-0
+---
+# Update-Tasks für Komodo Periphery.
+# Periphery wird nur auf Docker-Hosts verwaltet. Auf diesen wird die
+# Konfiguration idempotent abgeglichen (Erstinstall für Übergangsfälle bzw.
+# Übernahme von Config-Änderungen) und anschließend die Binary auf die neueste
+# Komodo-Version aktualisiert.
+
+- name: Prüfen ob Docker installiert ist
+  ansible.builtin.command: docker --version
+  register: docker_check
+  changed_when: false
+  failed_when: false
+
+- name: Periphery auf Docker-Hosts verwalten
+  when: docker_check.rc == 0
+  block:
+    - name: Periphery installieren/konfigurieren (idempotent)
+      ansible.builtin.include_tasks: main.yml
+      vars:
+        install_periphery: true
+
+    - name: Installierte Periphery-Version ermitteln
+      ansible.builtin.shell: "{{ periphery_bin }} --version 2>&1 | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+' | head -n1"
+      register: periphery_installed_version
+      changed_when: false
+      failed_when: false
+
+    - name: Neueste Komodo-Version von GitHub ermitteln
+      ansible.builtin.uri:
+        url: https://api.github.com/repos/moghtech/komodo/releases/latest
+        return_content: true
+      register: komodo_release
+
+    - name: Periphery-Architektur bestimmen
+      ansible.builtin.set_fact:
+        periphery_arch: "{{ 'aarch64' if ansible_facts['architecture'] == 'aarch64' else 'x86_64' }}"
+
+    - name: Neueste Version normalisieren (ohne führendes v)
+      ansible.builtin.set_fact:
+        periphery_latest_version: "{{ komodo_release.json.tag_name | regex_replace('^v', '') }}"
+
+    - name: Periphery-Binary aktualisieren
+      ansible.builtin.get_url:
+        url: "https://github.com/moghtech/komodo/releases/download/{{ komodo_release.json.tag_name }}/periphery-{{ periphery_arch }}"
+        dest: "{{ periphery_bin }}"
+        mode: "0755"
+        force: true
+      when: periphery_installed_version.stdout | default('') != periphery_latest_version
+      register: periphery_update_result
+
+    - name: Periphery neustarten nach Update
+      ansible.builtin.systemd:
+        name: periphery
+        state: restarted
+      when: periphery_update_result is changed

--- a/roles/komodo-periphery/templates/periphery.config.toml.j2
+++ b/roles/komodo-periphery/templates/periphery.config.toml.j2
@@ -1,0 +1,17 @@
+# Managed by Ansible (komodo-periphery role) - nicht manuell bearbeiten
+# Adaptiert aus der bisherigen docker-compose-Konfiguration.
+
+root_directory = "{{ periphery_root_directory }}"
+stack_dir = "{{ periphery_stack_dir }}"
+disable_terminals = {{ periphery_disable_terminals | ternary('true', 'false') }}
+include_disk_mounts = [{% for mount in periphery_include_disk_mounts %}"{{ mount }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+
+# Outbound-Mode: Periphery verbindet sich aktiv zu Komodo Core.
+core_address = "{{ komodo_core_address }}"
+connect_as = "{{ periphery_connect_as }}"
+{% if periphery_onboarding_key is defined and periphery_onboarding_key | length > 0 %}
+
+# Einmaliger Onboarding-Key (nur beim Erstinstall vorhanden). Periphery erzeugt
+# beim ersten Connect sein eigenes Keypair; danach wird dieser Eintrag entfernt.
+onboarding_key = "{{ periphery_onboarding_key }}"
+{% endif %}

--- a/roles/komodo-periphery/templates/periphery.service.j2
+++ b/roles/komodo-periphery/templates/periphery.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Komodo Periphery Agent
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+ExecStart=/bin/sh -lc "{{ periphery_bin }} --config-path {{ periphery_config_path }}"
+Restart=always
+RestartSec=3
+User=root
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/komodo-periphery/templates/periphery_update.j2
+++ b/roles/komodo-periphery/templates/periphery_update.j2
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Komodo Periphery Update Script (von Ansible verwaltet)
+# Hält die Periphery-Binary auf der neuesten Komodo-Version (kein Pinning).
+
+set -euo pipefail
+
+PERIPHERYPATH="{{ periphery_bin }}"
+REPO="moghtech/komodo"
+
+# Installierte Version auslesen
+get_installed_version() {
+  if [ -x "$PERIPHERYPATH" ]; then
+    "$PERIPHERYPATH" --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1
+  else
+    echo "none"
+  fi
+}
+
+# Neueste stabile Version (Release-Tag) von GitHub holen
+get_latest_tag() {
+  curl -s "https://api.github.com/repos/${REPO}/releases/latest" | jq -r '.tag_name'
+}
+
+# Architektur bestimmen (Komodo liefert nur x86_64 und aarch64)
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64)         echo "x86_64";;
+    aarch64|arm64)  echo "aarch64";;
+    *) echo "Nicht unterstützte Architektur: $(uname -m)" >&2; exit 1;;
+  esac
+}
+
+install_periphery() {
+  tag="$1"
+  arch="$(detect_arch)"
+  url="https://github.com/${REPO}/releases/download/${tag}/periphery-${arch}"
+  tmp="$(mktemp)"
+
+  echo "Lade periphery ${tag} (${arch}) herunter..."
+  if curl -fL -o "$tmp" "$url"; then
+    install -m 0755 "$tmp" "$PERIPHERYPATH"
+    rm -f "$tmp"
+    echo "Update erfolgreich."
+  else
+    rm -f "$tmp"
+    echo "Download fehlgeschlagen. URL: ${url}" >&2
+    exit 1
+  fi
+}
+
+installed_version="$(get_installed_version)"
+latest_tag="$(get_latest_tag)"
+latest_version="${latest_tag#v}"
+
+echo "Installierte Version: ${installed_version}"
+echo "Neueste Version: ${latest_version}"
+echo "System: $(detect_arch)"
+
+if [ "$installed_version" = "none" ]; then
+  echo "periphery ist nicht installiert. Installation wird gestartet."
+  install_periphery "$latest_tag"
+elif [ "$installed_version" != "$latest_version" ]; then
+  echo "Update verfügbar. Aktualisiere periphery auf ${latest_version}."
+  install_periphery "$latest_tag"
+  # Dienst nur neu starten, wenn er bereits existiert/läuft
+  if systemctl list-unit-files periphery.service >/dev/null 2>&1; then
+    systemctl restart periphery.service
+  fi
+else
+  echo "periphery ist bereits auf dem neuesten Stand."
+fi

--- a/roles/security/tasks/main.yml
+++ b/roles/security/tasks/main.yml
@@ -102,8 +102,10 @@
   register: ip_forward_config
 
 - name: IP-Forwarding live anwenden
-  # Nur wenn sich die Drop-in-Datei geändert hat -> kein churn im Normalbetrieb.
-  command: sysctl --system
+  # Nur die eigene Drop-in-Datei anwenden (nicht "sysctl --system"): in LXC sind
+  # diverse fremde Keys read-only, ein systemweites Anwenden würde mit rc=1
+  # scheitern. Nur wenn sich die Datei geändert hat -> kein churn im Normalbetrieb.
+  command: sysctl -p /etc/sysctl.d/99-ip-forward.conf
   changed_when: false
   when: ip_forward_config is changed
 


### PR DESCRIPTION
## Überblick

Führt den Komodo v2 Periphery-Agent **direkt über systemd** aus (analog zur `pangolin-newt`-Rolle) statt im Container, plus einen kleinen Bugfix an der `security`-Rolle.

## Commits

### 1. `fix(security)`: IP-Forwarding via `sysctl -p` statt `--system`
`sysctl --system` wendet alle sysctl-Dateien systemweit an und scheitert in LXC-Containern mit rc=1 (diverse `kernel.*`/`fs.*`-Keys sind dort read-only). Jetzt wird nur noch das eigene Drop-in angewendet → funktioniert auf Containern und Hosts.

### 2. `feat(komodo-periphery)`: Periphery als systemd-Dienst
- **API-Onboarding** (`CreateOnboardingKey`) nur beim Erstinstall; danach nutzt der Agent sein eigenes Ed25519-Keypair — kein langlebiges Secret in der Config.
- **Updater** (täglicher Cron) hält die Binary auf der neuesten `moghtech/komodo`-Release (kein Pinning).
- **Outbound-Mode**: verbindet zu Core über dessen **Tailscale-IP** (DNS-unabhängig; vermeidet den `/etc/hosts`-Kurzname-Fallstrick auf dem Core-Host selbst).
- **Setup**: Installation auf allen Docker-Hosts. **Update-Lauf**: gleicht Config + Binary ab und installiert auf Docker-Hosts nach, die es noch nicht haben (Übergangsfälle).
- API nutzt die **interne** Core-Adresse; die öffentliche UI-URL liegt hinter dem Pangolin-Auth-Proxy und lehnt API-Calls ab (302).

## Getestet
Live migriert und verifiziert auf `docker`, `lrm`, `pangolin` — alle drei verbinden als systemd-Agent (`Logged in … as Server <host>`), in Komodo `state=Ok`, v2.2.0.

## Hinweise für Reviewer
- `connect_as` muss dem Komodo-Servernamen entsprechen (case-sensitive); bestehende Server wurden via API von `Docker`/`Pangolin` auf Kleinschreibung umbenannt.
- 1Password-Item `Komodo` (Vault `CI`) mit Feldern `Key`/`Secret`; die `URL` darin (öffentliche UI) wird bewusst **nicht** für API-Calls verwendet.
- Der reine Onboarding-Pfad für *frische* Hosts ist noch ungetestet (bei allen Migrationen existierten bereits Keys), aber mit korrekter interner API-URL implementiert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)