### PR TITLE
fix(container-tools): avoid GitHub API rate limit in ctop version check

### DIFF
--- a/roles/container-tools/tasks/update.yml
+++ b/roles/container-tools/tasks/update.yml
@@ -14,11 +14,20 @@
   failed_when: false
   when: ctop_binary.stat.exists
 
+# Redirect von /releases/latest statt der API nutzen: kein Rate-Limit,
+# und "latest" enthält nie Prereleases oder Drafts
 - name: Neueste ctop-Version von GitHub ermitteln
   uri:
-    url: https://api.github.com/repos/bcicen/ctop/releases/latest
-    return_content: true
+    url: https://github.com/bcicen/ctop/releases/latest
+    follow_redirects: none
+    status_code: 302
   register: ctop_latest_release
+  when: ctop_binary.stat.exists
+
+# Redirect-Ziel ist .../releases/tag/v0.7.7 → basename liefert den Tag mit v-Präfix
+- name: Neuesten ctop-Tag bestimmen
+  set_fact:
+    ctop_latest_tag: "{{ ctop_latest_release.location | basename }}"
   when: ctop_binary.stat.exists
 
 - name: Host Architektur für ctop bestimmen
@@ -29,10 +38,10 @@
 
 - name: ctop aktualisieren
   get_url:
-    url: "https://github.com/bcicen/ctop/releases/download/{{ ctop_latest_release.json.tag_name }}/ctop-{{ ctop_latest_release.json.tag_name | regex_replace('^v', '') }}-linux-{{ ctop_arch }}"
+    url: "https://github.com/bcicen/ctop/releases/download/{{ ctop_latest_tag }}/ctop-{{ ctop_latest_tag | regex_replace('^v', '') }}-linux-{{ ctop_arch }}"
     dest: /usr/local/bin/ctop
     mode: "0755"
     force: true
   when:
     - ctop_binary.stat.exists
-    - ctop_installed_version.stdout | default('') != (ctop_latest_release.json.tag_name | regex_replace('^v', ''))
+    - ctop_installed_version.stdout | default('') != (ctop_latest_tag | regex_replace('^v', ''))


### PR DESCRIPTION
## What

Switch the ctop latest-version lookup in `roles/container-tools/tasks/update.yml` from the GitHub API (`api.github.com/repos/bcicen/ctop/releases/latest`) to the redirect of `github.com/bcicen/ctop/releases/latest` (`follow_redirects: none`, `status_code: 302`), extracting the tag from the `Location` header via `basename`.

## Why

Unauthenticated GitHub API calls are rate-limited to 60/h per IP, which already caused failures during newt updates. The `/releases/latest` redirect has no rate limit and never points to prereleases or drafts. Same approach as the newt fix on `fix-newt-update-rate-limit`.

## Notes for review

- The redirect target is `.../releases/tag/v0.7.7`, so `basename` yields the tag **with** the `v` prefix — the same format as `tag_name` from the API. The download URL (tag with `v` in the path, version without `v` in the filename) and the version comparison keep the existing `regex_replace('^v', '')` handling unchanged.
- Verified: the live redirect currently resolves to `v0.7.7`, and the resulting download URLs for amd64 and arm64 both return HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)